### PR TITLE
[#4] Fix error for invalid prefix path when using regex expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Fixed
+- [#4] Fix error for invalid prefix path when using regex expressions
 - use generic Namespace name from Env-Var "POD_NAMESPACE" instead of hardcoded "ecosystem"
 
 ## [v0.0.1] - 2025-09-04

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -53,3 +53,4 @@ ingress-nginx:
       annotations-risk-level: "Critical"
       disable-access-log: "false"
       error-log-level: "info"
+      strict-validate-path-type: "false"


### PR DESCRIPTION
The current nginx ingress version sets the default for strict-validate-path-type to true, which only allows alphanumeric for the path. For Nexus, we are using a regex expression, which is stated as invalid. As the ingress is invalid, the docker registry is not accessible.

By setting strict-validate-path-type to false the validation is disabled for the moment.