### PR TITLE
#31 buffer only non encoded html content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#31] Buffer only non encoded html-content
+  - This allows streaming responses in the custom middleware-plugins
 
 ## [v3.2.0] - 2026-05-06
 ### Security

--- a/k8s/helm/files/ces-error-pages/errorpages.go
+++ b/k8s/helm/files/ces-error-pages/errorpages.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net"
 	"net/http"
 	"strconv"
@@ -71,54 +72,40 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 
 func (s *cesErrorPages) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	wrappedWriter := &responseWriter{
-		ResponseWriter: rw,
-		statusCode:     http.StatusOK,
+		originalRw: rw,
+		statusCode: http.StatusOK,
 	}
 
 	s.next.ServeHTTP(wrappedWriter, req)
 
-	statusCode := wrappedWriter.statusCode
+	if !wrappedWriter.wroteHeader {
+		wrappedWriter.WriteHeader(http.StatusOK)
+	}
 
-	// Check if this status code should be handled
-	if !s.statusCodes[statusCode] {
-		s.writeResponse(rw, wrappedWriter, statusCode)
+	if wrappedWriter.passthrough {
 		return
 	}
 
-	contentType := wrappedWriter.Header().Get("Content-Type")
+	statusCode := wrappedWriter.statusCode
+
 	bodyBytes := wrappedWriter.buffer.Bytes()
+
+	// Check if this status code should be handled
+	if !s.statusCodes[statusCode] {
+		wrappedWriter.commit(bodyBytes)
+		return
+	}
 
 	// only redirect to error page if the content type is HTML and the body is empty
 	// some dogus send incorrect status codes with valid html bodies, these should not be redirected
-	if s.isHTMLContent(contentType) && s.isEmptyBody(bodyBytes) {
+	if s.isEmptyBody(bodyBytes) {
 		log.Printf("[CesErrorPages] Redirecting status %d with empty HTML body to error page", statusCode)
 		s.redirectToErrorPage(rw, req, statusCode)
 		return
 	}
 
 	// write original response
-	s.writeResponse(rw, wrappedWriter, statusCode)
-}
-
-func (s *cesErrorPages) writeResponse(rw http.ResponseWriter, wrappedWriter *responseWriter, statusCode int) {
-	for key, values := range wrappedWriter.Header() {
-		// content-length is set automatically
-		if key == "Content-Length" {
-			continue
-		}
-		rw.Header().Del(key)
-		for _, value := range values {
-			rw.Header().Add(key, value)
-		}
-	}
-
-	// Write status code
-	rw.WriteHeader(statusCode)
-
-	// Write body
-	if _, err := rw.Write(wrappedWriter.buffer.Bytes()); err != nil {
-		log.Printf("[CesErrorPages] unable to write body: %v", err)
-	}
+	wrappedWriter.commit(bodyBytes)
 }
 
 // redirectToErrorPage redirects the client to the error page for the given status code
@@ -184,31 +171,127 @@ func (s *cesErrorPages) isEmptyBody(body []byte) bool {
 }
 
 type responseWriter struct {
-	buffer     bytes.Buffer
-	statusCode int
+	buffer      bytes.Buffer
+	wroteHeader bool
+	statusCode  int
 
-	http.ResponseWriter
+	header      http.Header
+	originalRw  http.ResponseWriter
+	passthrough bool
+}
+
+func (r *responseWriter) Header() http.Header {
+	if r.passthrough {
+		return r.originalRw.Header()
+	}
+
+	if r.header == nil {
+		r.header = make(http.Header)
+	}
+
+	return r.header
+}
+
+func (r *responseWriter) isContentReplacable() bool {
+	contentType := r.Header().Get("Content-Type")
+	mtype, _, _ := mime.ParseMediaType(contentType)
+
+	if strings.ToLower(mtype) != "text/html" {
+		return false
+	}
+
+	encoding := r.Header().Get("Content-Encoding")
+	if encoding == "" {
+		return true
+	}
+
+	ctype, _, err := mime.ParseMediaType(encoding)
+	if err != nil {
+		return false
+	}
+
+	return ctype == "" || strings.ToLower(ctype) == "identity"
 }
 
 func (r *responseWriter) WriteHeader(statusCode int) {
+	if r.wroteHeader {
+		return
+	}
+	r.wroteHeader = true
+
+	if r.passthrough {
+		r.originalRw.WriteHeader(statusCode)
+		return
+	}
+
 	r.statusCode = statusCode
-	// Don't call ResponseWriter.WriteHeader yet - we need to buffer everything first
+
+	if !r.isContentReplacable() {
+		r.passthrough = true
+		applyHeader(r.originalRw.Header(), r.header)
+		r.originalRw.WriteHeader(statusCode)
+	}
 }
 
-func (r *responseWriter) Write(p []byte) (int, error) {
-	return r.buffer.Write(p)
+func (r *responseWriter) Write(data []byte) (n int, err error) {
+	if !r.wroteHeader {
+		r.WriteHeader(http.StatusOK)
+	}
+
+	if r.passthrough {
+		return r.originalRw.Write(data)
+	}
+
+	return r.buffer.Write(data)
+}
+
+func (r *responseWriter) commit(body []byte) {
+	status := r.statusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+
+	r.header.Del("Content-Length")
+	applyHeader(r.originalRw.Header(), r.header)
+	r.originalRw.WriteHeader(status)
+
+	if _, err := r.originalRw.Write(body); err != nil {
+		log.Printf("unable to write body: %v", err)
+	}
+}
+
+func cloneHeader(src http.Header) http.Header {
+	dst := make(http.Header, len(src))
+	for k, vv := range src {
+		cpy := make([]string, len(vv))
+		copy(cpy, vv)
+		dst[k] = cpy
+	}
+	return dst
+}
+
+func applyHeader(dst, src http.Header) {
+	for k := range dst {
+		dst.Del(k)
+	}
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
 }
 
 func (r *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	hijacker, ok := r.ResponseWriter.(http.Hijacker)
+	hijacker, ok := r.originalRw.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", r.ResponseWriter)
+		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", r.originalRw)
 	}
+
 	return hijacker.Hijack()
 }
 
 func (r *responseWriter) Flush() {
-	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+	if flusher, ok := r.originalRw.(http.Flusher); ok {
 		flusher.Flush()
 	}
 }

--- a/k8s/helm/files/ces-error-pages/errorpages.go
+++ b/k8s/helm/files/ces-error-pages/errorpages.go
@@ -74,6 +74,7 @@ func (s *cesErrorPages) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	wrappedWriter := &responseWriter{
 		originalRw: rw,
 		statusCode: http.StatusOK,
+		header:       cloneHeader(rw.Header()),
 	}
 
 	s.next.ServeHTTP(wrappedWriter, req)
@@ -154,15 +155,6 @@ func (s *cesErrorPages) redirectToErrorPage(rw http.ResponseWriter, req *http.Re
 	if _, err := io.Copy(rw, resp.Body); err != nil {
 		log.Printf("[CesErrorPages] error writing error page body: %v", err)
 	}
-}
-
-// isHTMLContent checks for text/html content type (with or without charset)
-func (s *cesErrorPages) isHTMLContent(contentType string) bool {
-	if contentType == "" {
-		return false
-	}
-	contentType = strings.ToLower(strings.TrimSpace(contentType))
-	return strings.HasPrefix(contentType, "text/html")
 }
 
 // isEmptyBody checks if body is empty or contains only whitespace

--- a/k8s/helm/files/nonce/nonce.go
+++ b/k8s/helm/files/nonce/nonce.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"mime"
 	"net"
 	"net/http"
 	"regexp"
@@ -29,13 +30,14 @@ type nonce struct {
 }
 
 type responseWriter struct {
-	buffer      bytes.Buffer
-	wroteHeader bool
-	nonce       string
-	statusCode  int
+	buffer       bytes.Buffer
+	wroteHeader  bool
+	statusCode   int
+	nonce        string
 
-	header http.Header
-	http.ResponseWriter
+	header       http.Header
+	originalRw   http.ResponseWriter
+	passthrough  bool
 }
 
 // New creates and returns a new nonce plugin instance.
@@ -47,31 +49,27 @@ func New(_ context.Context, next http.Handler, _ *Config, name string) (http.Han
 
 func (n *nonce) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	wrappedWriter := &responseWriter{
-		ResponseWriter: rw,
+		originalRw: rw,
 		nonce:          generateNonce(),
 		header:         cloneHeader(rw.Header()),
 	}
 
 	n.next.ServeHTTP(wrappedWriter, req)
+
+	if !wrappedWriter.wroteHeader {
+		wrappedWriter.WriteHeader(http.StatusOK)
+	}
+
+	if wrappedWriter.passthrough {
+		return
+	}
+
 	bodyBytes := wrappedWriter.buffer.Bytes()
-
-	contentEncoding := wrappedWriter.Header().Get("Content-Encoding")
-	if contentEncoding != "" && contentEncoding != "identity" {
-		wrappedWriter.commitTo(rw, bodyBytes)
-		return
-	}
-
-	// Check if response is HTML before adding nonces
-	contentType := wrappedWriter.Header().Get("Content-Type")
-	if !isHTMLContent(contentType) {
-		wrappedWriter.commitTo(rw, bodyBytes)
-		return
-	}
 
 	bodyBytes = wrappedWriter.addNonceToScriptTags(bodyBytes)
 	wrappedWriter.updateCSPWithNonce()
 
-	wrappedWriter.commitTo(rw, bodyBytes)
+	wrappedWriter.commit(bodyBytes)
 }
 
 // generateNonce creates a cryptographically secure random nonce
@@ -118,48 +116,85 @@ func (r *responseWriter) addNonceToScriptTags(body []byte) []byte {
 	return result
 }
 
+func (r *responseWriter) Header() http.Header {
+	if r.passthrough {
+		return r.originalRw.Header()
+	}
+
+	if r.header == nil {
+		r.header = make(http.Header)
+	}
+
+	return r.header
+}
+
+func (r *responseWriter) isContentReplacable() bool {
+	contentType := r.Header().Get("Content-Type")
+	mtype, _, _ := mime.ParseMediaType(contentType)
+
+	if strings.ToLower(mtype) != "text/html" {
+		return false
+	}
+
+	encoding := r.Header().Get("Content-Encoding")
+	if encoding == "" {
+		return true
+	}
+
+	ctype, _, err := mime.ParseMediaType(encoding)
+	if err != nil {
+		return false
+	}
+
+	return ctype == "" || strings.ToLower(ctype) == "identity"
+}
+
 func (r *responseWriter) WriteHeader(statusCode int) {
 	if r.wroteHeader {
 		return
 	}
-
 	r.wroteHeader = true
+
+	if r.passthrough {
+		r.originalRw.WriteHeader(statusCode)
+		return
+	}
+
 	r.statusCode = statusCode
 
-	// Delegates the Content-Length Header creation to the final body write.
-	r.Header().Del("Content-Length")
+	if !r.isContentReplacable() {
+		r.passthrough = true
+		applyHeader(r.originalRw.Header(), r.header)
+		r.originalRw.WriteHeader(statusCode)
+	}
 }
 
-func (r *responseWriter) Write(p []byte) (int, error) {
+func (r *responseWriter) Write(data []byte) (n int, err error) {
 	if !r.wroteHeader {
 		r.WriteHeader(http.StatusOK)
 	}
 
-	return r.buffer.Write(p)
+	if r.passthrough {
+		return r.originalRw.Write(data)
+	}
+
+	return r.buffer.Write(data)
 }
 
-func (r *responseWriter) commitTo(rw http.ResponseWriter, body []byte) {
+func (r *responseWriter) commit(body []byte) {
 	status := r.statusCode
 	if status == 0 {
 		status = http.StatusOK
 	}
 
-	r.Header().Del("Content-Length")
-	applyHeader(rw.Header(), r.Header())
-	rw.WriteHeader(status)
+	r.header.Del("Content-Length")
+	applyHeader(r.originalRw.Header(), r.header)
+	r.originalRw.WriteHeader(status)
 
-	if _, err := rw.Write(body); err != nil {
+	if _, err := r.originalRw.Write(body); err != nil {
 		log.Printf("unable to write body: %v", err)
 	}
 }
-
-func (r *responseWriter) Header() http.Header {
-	if r.header == nil {
-		r.header = make(http.Header)
-	}
-	return r.header
-}
-
 func cloneHeader(src http.Header) http.Header {
 	dst := make(http.Header, len(src))
 	for k, vv := range src {
@@ -182,26 +217,16 @@ func applyHeader(dst, src http.Header) {
 }
 
 func (r *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	hijacker, ok := r.ResponseWriter.(http.Hijacker)
+	hijacker, ok := r.originalRw.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", r.ResponseWriter)
+		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", r.originalRw)
 	}
 
 	return hijacker.Hijack()
 }
 
 func (r *responseWriter) Flush() {
-	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+	if flusher, ok := r.originalRw.(http.Flusher); ok {
 		flusher.Flush()
 	}
-}
-
-// isHTMLContent checks if the content type indicates HTML
-func isHTMLContent(contentType string) bool {
-	if contentType == "" {
-		return false
-	}
-
-	// Check for text/html (with or without charset)
-	return len(contentType) >= 9 && contentType[:9] == "text/html"
 }

--- a/k8s/helm/files/rewritebody/rewritebody.go
+++ b/k8s/helm/files/rewritebody/rewritebody.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"mime"
 	"net"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 // Rewrite holds one rewrite body configuration.
@@ -48,8 +50,9 @@ type responseWriter struct {
 	wroteHeader  bool
 	statusCode   int
 
-	header http.Header
-	http.ResponseWriter
+	header       http.Header
+	originalRw   http.ResponseWriter
+	passthrough  bool
 }
 
 // New creates and returns a new rewrite body plugin instance.
@@ -78,78 +81,110 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 
 func (r *rewriteBody) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	wrappedWriter := &responseWriter{
-		lastModified:   r.lastModified,
-		ResponseWriter: rw,
-		header:         cloneHeader(rw.Header()),
+		lastModified: r.lastModified,
+		originalRw:   rw,
+		header:       cloneHeader(rw.Header()),
 	}
 
 	r.next.ServeHTTP(wrappedWriter, req)
 
+	if !wrappedWriter.wroteHeader {
+		wrappedWriter.WriteHeader(http.StatusOK)
+	}
+
+	if wrappedWriter.passthrough {
+		return
+	}
+
 	bodyBytes := wrappedWriter.buffer.Bytes()
 
-	contentEncoding := wrappedWriter.Header().Get("Content-Encoding")
-	if contentEncoding != "" && contentEncoding != "identity" {
-		wrappedWriter.commitTo(rw, bodyBytes)
-		return
-	}
-
-	// Check if response is HTML before rewriting
-	contentType := wrappedWriter.Header().Get("Content-Type")
-	if !isHTMLContent(contentType) {
-		wrappedWriter.commitTo(rw, bodyBytes)
-		return
-	}
-
 	for _, rwt := range r.rewrites {
-		replacement := rwt.replacement
-		bodyBytes = rwt.regex.ReplaceAll(bodyBytes, replacement)
+		bodyBytes = rwt.regex.ReplaceAll(bodyBytes, rwt.replacement)
 	}
 
-	wrappedWriter.commitTo(rw, bodyBytes)
+	wrappedWriter.commit(bodyBytes)
 }
 
 func (r *responseWriter) Header() http.Header {
+	if r.passthrough {
+		return r.originalRw.Header()
+	}
+
 	if r.header == nil {
 		r.header = make(http.Header)
 	}
+
 	return r.header
+}
+
+func (r *responseWriter) isContentReplacable() bool {
+	contentType := r.Header().Get("Content-Type")
+	mtype, _, _ := mime.ParseMediaType(contentType)
+
+	if strings.ToLower(mtype) != "text/html" {
+		return false
+	}
+
+	encoding := r.Header().Get("Content-Encoding")
+	if encoding == "" {
+		return true
+	}
+
+	ctype, _, err := mime.ParseMediaType(encoding)
+	if err != nil {
+		return false
+	}
+
+	return ctype == "" || strings.ToLower(ctype) == "identity"
 }
 
 func (r *responseWriter) WriteHeader(statusCode int) {
 	if r.wroteHeader {
 		return
 	}
+	r.wroteHeader = true
 
-	if !r.lastModified {
-		r.Header().Del("Last-Modified")
+	if r.passthrough {
+		r.originalRw.WriteHeader(statusCode)
+		return
 	}
 
-	r.wroteHeader = true
 	r.statusCode = statusCode
 
-	// Delegates the Content-Length Header creation to the final body write.
-	r.Header().Del("Content-Length")
+	if r.isContentReplacable() {
+		if !r.lastModified {
+			r.header.Del("Last-Modified")
+		}
+	} else {
+		r.passthrough = true
+		applyHeader(r.originalRw.Header(), r.header)
+		r.originalRw.WriteHeader(statusCode)
+	}
 }
 
-func (r *responseWriter) Write(p []byte) (int, error) {
+func (r *responseWriter) Write(data []byte) (n int, err error) {
 	if !r.wroteHeader {
 		r.WriteHeader(http.StatusOK)
 	}
 
-	return r.buffer.Write(p)
+	if r.passthrough {
+		return r.originalRw.Write(data)
+	}
+
+	return r.buffer.Write(data)
 }
 
-func (r *responseWriter) commitTo(rw http.ResponseWriter, body []byte) {
+func (r *responseWriter) commit(body []byte) {
 	status := r.statusCode
 	if status == 0 {
 		status = http.StatusOK
 	}
 
-	r.Header().Del("Content-Length")
-	applyHeader(rw.Header(), r.Header())
-	rw.WriteHeader(status)
+	r.header.Del("Content-Length")
+	applyHeader(r.originalRw.Header(), r.header)
+	r.originalRw.WriteHeader(status)
 
-	if _, err := rw.Write(body); err != nil {
+	if _, err := r.originalRw.Write(body); err != nil {
 		log.Printf("unable to write body: %v", err)
 	}
 }
@@ -176,26 +211,16 @@ func applyHeader(dst, src http.Header) {
 }
 
 func (r *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	hijacker, ok := r.ResponseWriter.(http.Hijacker)
+	hijacker, ok := r.originalRw.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", r.ResponseWriter)
+		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", r.originalRw)
 	}
 
 	return hijacker.Hijack()
 }
 
 func (r *responseWriter) Flush() {
-	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+	if flusher, ok := r.originalRw.(http.Flusher); ok {
 		flusher.Flush()
 	}
-}
-
-// isHTMLContent checks if the content type indicates HTML
-func isHTMLContent(contentType string) bool {
-	if contentType == "" {
-		return false
-	}
-
-	// Check for text/html (with or without charset)
-	return len(contentType) >= 9 && contentType[:9] == "text/html"
 }


### PR DESCRIPTION
This change only buffers requests if the content is of type html and non encoded. All requests with other content types (stream, downloads etc.) are being passed through.

Resolves #31